### PR TITLE
Update @tokenizer/range v0.3 using strtok3 v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "url": "https://github.com/Borewit/tokenizer-s3/issues"
   },
   "dependencies": {
-    "@tokenizer/range": "^0.2.1",
-    "strtok3": "^5.0.0"
+    "@tokenizer/range": "^0.3.0",
+    "strtok3": "^6.0.0"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,18 +39,23 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@tokenizer/range@^0.2.1":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@tokenizer/range/-/range-0.2.2.tgz#c7698af4ae6ca2efb8b06d88f60555fa99256b97"
-  integrity sha512-yzJ7oRzs1kMnpDaBFptCiLZL0AJakLr2q2+EoRVZY3Csg9QKPuN5FRlHfpeipHo0tAp5d3OvJG7s+/bXP2Ntzw==
+"@tokenizer/range@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@tokenizer/range/-/range-0.3.0.tgz#d44c2ff1e453c8b50d0c020873353197fe059757"
+  integrity sha512-faZqalupzRzzRWhTAWLWuBqWkN5j83WeO3xSMBnpR76WYTb+j/ExqLks2n1QFVTkiZKDXBhjqCMPudfWdYwByQ==
   dependencies:
     debug "^4.1.1"
-    strtok3 "^5.0.0"
+    strtok3 "^6.0.0"
 
 "@tokenizer/token@^0.1.1":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.1.1.tgz#f0d92c12f87079ddfd1b29f614758b9696bc29e3"
   integrity sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w==
+
+"@types/debug@^4.1.5":
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
+  integrity sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
 
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
@@ -1817,12 +1822,13 @@ strip-json-comments@^3.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
   integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
 
-strtok3@^5.0.0:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-5.0.2.tgz#bb81f1f56742e16f1a30ccce5dc3d9498aa5475a"
-  integrity sha512-EFeVpFC5qDsqPEJSrIYyS/ueFBknGhgSK9cW+YAJF/cgJG/KSjoK7X6rK5xnpcLe7y1LVkVFCXWbAb+ClNKzKQ==
+strtok3@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-6.0.0.tgz#d6b900863daeacfe6c1724c6e7bb36d7a58e83c8"
+  integrity sha512-ZXlmE22LZnIBvEU3n/kZGdh770fYFie65u5+2hLK9s74DoFtpkQIdBZVeYEzlolpGa+52G5IkzjUWn+iXynOEQ==
   dependencies:
     "@tokenizer/token" "^0.1.1"
+    "@types/debug" "^4.1.5"
     debug "^4.1.1"
     peek-readable "^3.1.0"
 


### PR DESCRIPTION
Update to [@tokenizer/range@v0.3.0](https://github.com/Borewit/tokenizer-range/releases/tag/v0.3.0) with [strtok3 v6](https://github.com/Borewit/strtok3/releases/tag/v6.0.0)