### PR TITLE
Remove aws-sdk@2

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "@types/node": "^18.11.9",
     "@typescript-eslint/eslint-plugin": "^4.0.0",
     "@typescript-eslint/parser": "^3.0.0",
-    "aws-sdk": "^2.1260.0",
     "chai": "^4.3.7",
     "del-cli": "^5.0.0",
     "eslint": "^7.0.0",


### PR DESCRIPTION
Following from my comment [here](https://github.com/Borewit/tokenizer-s3/pull/555#issuecomment-1331394779), the aws-sdk v2 is around [75MB uncompressed & installed](https://packagephobia.com/result?p=aws-sdk) (since it's non-modular unlike v3), so it'd be great to get that out!