### PR TITLE
Add support for random-access-reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,51 @@ or
 
 ## API Documention
 
-### `makeTokenizer`
+### `makeChunkedTokenizerFromS3`
+
+Initialize a tokenizer, with the option for random access, 
+from an Amazon S3 client for use in extracting metadata from media files.
+
+#### Function Signature
+
+```ts
+function makeChunkedTokenizerFromS3(s3: S3Client, objRequest: GetObjectRequest): Promise<IRandomAccessTokenizer>
+```
+Reads from the S3 as a stream.
+
+#### Parameters
+
+- `s3` (`S3Client`):
+
+  The S3 client used to make requests to Amazon S3.
+  > [!NOTE]
+  > To configure AWS client authentication see [Configuration and credential file settings](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html).
+
+- `objRequest` (`GetObjectRequest`):
+
+  The S3 object request containing details about the S3 object to fetch.
+  This includes properties like the bucket name and object key.
+
+- `options` (`IS3Options`, optional):
+
+#### Returns
+
+- `Promise<IRandomAccessTokenizer>`:
+
+  A Promise that resolves to an instance of `IRandomAccessTokenizer`.
+  This tokenizer can be used to extract metadata from the specified media file in the S3 object.
+  It supports [random access](https://en.wikipedia.org/wiki/Random_access) reads. 
+
+### `makeStreamingTokenizerFromS3`
 
 Initialize a tokenizer from an Amazon S3 client for use in extracting metadata from media files.
 
 #### Function Signature
 
 ```ts
-async function makeTokenizer(
-  s3: S3Client, 
-  objRequest: GetObjectRequest, 
-  options?: IS3Options
-): Promise<ITokenizer>
+function makeStreamingTokenizerFromS3(s3: S3Client, objRequest: GetObjectRequest): Promise<ITokenizer>
 ```
+Reads from the S3 as a stream.
 
 #### Parameters
 
@@ -56,14 +88,6 @@ async function makeTokenizer(
   
   The S3 object request containing details about the S3 object to fetch.
   This includes properties like the bucket name and object key.
-
-- `options` (`IS3Options`, optional):
-  
-  Optional configuration settings for the tokenizer.
-
-  - `disableChunked`: When set to `true`, disables chunked requests and instead fetches the full object with ranged requests.
-
-  For remaining options see [strtok3](https://github.com/Borewit/strtok3/blob/master/README.md).
 
 #### Returns
  
@@ -89,7 +113,7 @@ Determine file type (based on it's content) from a file stored Amazon S3 cloud:
 import { fileTypeFromTokenizer } from 'file-type';
 import { fromEnv } from '@aws-sdk/credential-providers';
 import { S3Client } from '@aws-sdk/client-s3';
-import { makeTokenizer } from '@tokenizer/s3';
+import { makeChunkedTokenizerFromS3 } from '@tokenizer/s3';
 
 (async () => {
 
@@ -100,7 +124,7 @@ import { makeTokenizer } from '@tokenizer/s3';
   });
 
   // Initialize S3 tokenizer
-  const s3Tokenizer = await makeTokenizer(s3, {
+  const s3Tokenizer = await makeChunkedTokenizerFromS3(s3, {
     Bucket: 'affectlab',
     Key: '1min_35sec.mp4'
   });
@@ -117,7 +141,7 @@ See also [example at file-type](https://github.com/sindresorhus/file-type#filety
 
 Retrieve music-metadata 
 ```js
-import { makeTokenizer } from '@tokenizer/s3';
+import { makeChunkedTokenizerFromS3 } from '@tokenizer/s3';
 import { S3Client } from '@aws-sdk/client-s3';
 import { parseFromTokenizer } from 'music-metadata/lib/core';
 
@@ -128,7 +152,7 @@ import { parseFromTokenizer } from 'music-metadata/lib/core';
  * @return Metadata
  */
 async function parseS3Object(s3, objRequest, options) {
-  const s3Tokenizer = await makeTokenizer(s3, objRequest, options);
+  const s3Tokenizer = await makeChunkedTokenizerFromS3(s3, objRequest);
   return parseFromTokenizer(s3Tokenizer, options);
 }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,37 +1,37 @@
 import { type S3Client, type GetObjectRequest, GetObjectCommand } from '@aws-sdk/client-s3';
 import { parseContentRange, tokenizer } from '@tokenizer/range';
-import { fromStream, type ITokenizer, type ITokenizerOptions } from 'strtok3';
+import { fromStream, type ITokenizer, type IRandomAccessTokenizer } from 'strtok3';
 import { S3Request } from './s3-request.js';
 import type { Readable } from 'node:stream';
 
-export interface IS3Options extends ITokenizerOptions {
-  /**
-   * Flag to disable chunked transfer, use conventional HTTPS stream instead
-   */
-  disableChunked?: boolean;
+/**
+ * Initialize streaming tokenizer
+ * @param s3 client
+ * @param objRequest S3 object request
+ * @return Tokenizer supporting random-access
+ */
+export async function makeStreamingTokenizerFromS3(s3: S3Client, objRequest: GetObjectRequest): Promise<ITokenizer> {
+  const s3request = new S3Request(s3, objRequest);
+  const info = await s3request.getRangedRequest([0, 0]);
+  const contentRange = parseContentRange(info.ContentRange as string);
+  const output = await s3.send(new GetObjectCommand(objRequest));
+  return fromStream(output.Body as Readable, {
+    fileInfo: {
+      mimeType: info.ContentType,
+      size: contentRange.instanceLength
+    }
+  });
 }
 
 /**
- * Initialize tokenizer from S3 object
+ * Initialize chunked / random access tokenizer to S3 object
  * @param s3 S3 client
  * @param objRequest S3 object request
- * @param options S3 tokenizer options
- * @return Tokenizer
+ * @return Streaming tokenizer
  */
-export async function makeTokenizer(s3: S3Client, objRequest: GetObjectRequest, options?: IS3Options): Promise<ITokenizer> {
+export async function makeChunkedTokenizerFromS3(s3: S3Client, objRequest: GetObjectRequest): Promise<IRandomAccessTokenizer> {
   const s3request = new S3Request(s3, objRequest);
-  if (options?.disableChunked) {
-    const info = await s3request.getRangedRequest([0, 0]);
-    const contentRange = parseContentRange(info.ContentRange as string);
-    const output = await s3.send(new GetObjectCommand(objRequest));
-    return fromStream(output.Body as Readable, {...options, ...{
-      fileInfo: {
-        mimeType: info.ContentType,
-        size: contentRange.instanceLength
-      }
-    }});
-  }
-    return tokenizer(s3request, {
-      avoidHeadRequests: true
-    });
+  return tokenizer(s3request, {
+    avoidHeadRequests: true
+  });
 }

--- a/lib/s3-request.ts
+++ b/lib/s3-request.ts
@@ -47,7 +47,7 @@ export class S3Request implements IRangeRequestClient {
     const contentRange = parseContentRange(response.ContentRange as string);
 
     return {
-      size: contentRange?.instanceLength,
+      size: contentRange?.instanceLength as number,
       mimeType: response.ContentType,
       contentRange,
       acceptPartialRequests: true,

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.679.0",
     "@aws-sdk/credential-providers": "^3.679.0",
-    "@tokenizer/range": "^0.10.0",
-    "strtok3": "^9.0.1"
+    "@tokenizer/range": "^0.11.1",
+    "strtok3": "^9.1.0"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1619,13 +1619,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tokenizer/range@npm:^0.10.0":
-  version: 0.10.0
-  resolution: "@tokenizer/range@npm:0.10.0"
+"@tokenizer/range@npm:^0.11.1":
+  version: 0.11.1
+  resolution: "@tokenizer/range@npm:0.11.1"
   dependencies:
-    debug: "npm:^4.3.6"
-    strtok3: "npm:^9.0.0"
-  checksum: 10c0/3e036c79f20cd3a88dd58fa249c5d2ce1d986d85a4678f97d40db67c3eba4a2e9b5eaf70869b78919e61e13573a1209de96c421228d39b0025a540df606466c7
+    debug: "npm:^4.3.7"
+    strtok3: "npm:^9.1.1"
+  checksum: 10c0/490600bc2acc0c8e76d2fbfdf9497fc5ee7599a29282222062e2dd5420a51816eb15ebc42fdcfb30292ca454fb65bb413ec69507434d18f089f40c318a11501d
   languageName: node
   linkType: hard
 
@@ -1636,7 +1636,7 @@ __metadata:
     "@aws-sdk/client-s3": "npm:^3.679.0"
     "@aws-sdk/credential-providers": "npm:^3.679.0"
     "@biomejs/biome": "npm:1.9.4"
-    "@tokenizer/range": "npm:^0.10.0"
+    "@tokenizer/range": "npm:^0.11.1"
     "@tokenizer/token": "npm:^0.3.0"
     "@types/chai": "npm:^4.3.19"
     "@types/mocha": "npm:^10.0.9"
@@ -1646,7 +1646,7 @@ __metadata:
     file-type: "npm:^19.6.0"
     mocha: "npm:^10.7.3"
     music-metadata: "npm:^10.5.1"
-    strtok3: "npm:^9.0.1"
+    strtok3: "npm:^9.1.0"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.6.3"
   languageName: unknown
@@ -2025,7 +2025,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.3.4, debug@npm:^4.3.6":
+"debug@npm:4, debug@npm:^4.3.4":
   version: 4.3.6
   resolution: "debug@npm:4.3.6"
   dependencies:
@@ -3038,13 +3038,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"peek-readable@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "peek-readable@npm:5.2.0"
-  checksum: 10c0/7647d56786c94fc7f5f39923ef5f6ed1da7be92a2c221b743db74f1517821b1e944cc965d8f018a7e6984d969b6ced8a0c421aece7996c0b1981eac9daa4c323
-  languageName: node
-  linkType: hard
-
 "peek-readable@npm:^5.3.1":
   version: 5.3.1
   resolution: "peek-readable@npm:5.3.1"
@@ -3305,16 +3298,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strtok3@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "strtok3@npm:9.0.0"
-  dependencies:
-    "@tokenizer/token": "npm:^0.3.0"
-    peek-readable: "npm:^5.2.0"
-  checksum: 10c0/7d7cde9c5a3b195131f3652c8b0cb20d96e80b10d30a19294379e4302d0d4952bdc24a516c8a6cfa82bcb96f5b47e49ec917e8cc23c81052044a2ec41d15fb30
-  languageName: node
-  linkType: hard
-
 "strtok3@npm:^9.0.1":
   version: 9.0.1
   resolution: "strtok3@npm:9.0.1"
@@ -3322,6 +3305,26 @@ __metadata:
     "@tokenizer/token": "npm:^0.3.0"
     peek-readable: "npm:^5.3.1"
   checksum: 10c0/ab96030c3d30899fc885ed87b305086b6421d64c1a2b9f5240c6ecffde7b819e174d67bd3b1ecc14a10f539c7a818a0ac47386b4bbb2fa913f673b6ed1c0eb78
+  languageName: node
+  linkType: hard
+
+"strtok3@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "strtok3@npm:9.1.0"
+  dependencies:
+    "@tokenizer/token": "npm:^0.3.0"
+    peek-readable: "npm:^5.3.1"
+  checksum: 10c0/703699e49dd205bdf353ea974a12cbe858c0fd5d1f3ee42ca7314805f6b65aae968ff85b7dbb28d981b1f9bd909da2ec4132c58a9476cb155a86c9ca324604b8
+  languageName: node
+  linkType: hard
+
+"strtok3@npm:^9.1.1":
+  version: 9.1.1
+  resolution: "strtok3@npm:9.1.1"
+  dependencies:
+    "@tokenizer/token": "npm:^0.3.0"
+    peek-readable: "npm:^5.3.1"
+  checksum: 10c0/ef9cd2a6cd21aec368c7f6fbd1d93548adc2c5b69ee28fa9a4b4e8fb6be6e539f3fcdf21107196e0c3fdff1c433db7e5d0fb8cab132c0b013ed9eef220bdcf2f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Changes:
- Update dependency `@tokenizer/range` to [0.11.1](https://github.com/Borewit/tokenizer-range/releases/tag/v0.11.1)
- Replaced method `makeTokenizer` with:
  - `makeChunkedTokenizerFromS3` for chunked / random-access reads
  - `makeStreamingTokenizerFromS3` for streaming the S3 content