### PR TITLE
Refactor S3 client to use a more generic interface

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,7 @@
-import { type S3Client, type GetObjectRequest, GetObjectCommand } from '@aws-sdk/client-s3';
+import { type GetObjectRequest, GetObjectCommand } from '@aws-sdk/client-s3';
 import { parseContentRange, tokenizer } from '@tokenizer/range';
 import { fromStream, type ITokenizer, type IRandomAccessTokenizer } from 'strtok3';
-import { S3Request } from './s3-request.js';
+import { S3Request, type S3RequestClient } from './s3-request.js';
 import type { Readable } from 'node:stream';
 
 /**
@@ -10,7 +10,7 @@ import type { Readable } from 'node:stream';
  * @param objRequest S3 object request
  * @return Tokenizer supporting random-access
  */
-export async function makeStreamingTokenizerFromS3(s3: S3Client, objRequest: GetObjectRequest): Promise<ITokenizer> {
+export async function makeStreamingTokenizerFromS3(s3: S3RequestClient, objRequest: GetObjectRequest): Promise<ITokenizer> {
   const s3request = new S3Request(s3, objRequest);
   const info = await s3request.getRangedRequest([0, 0]);
   const contentRange = parseContentRange(info.ContentRange as string);
@@ -29,7 +29,7 @@ export async function makeStreamingTokenizerFromS3(s3: S3Client, objRequest: Get
  * @param objRequest S3 object request
  * @return Streaming tokenizer
  */
-export async function makeChunkedTokenizerFromS3(s3: S3Client, objRequest: GetObjectRequest): Promise<IRandomAccessTokenizer> {
+export async function makeChunkedTokenizerFromS3(s3: S3RequestClient, objRequest: GetObjectRequest): Promise<IRandomAccessTokenizer> {
   const s3request = new S3Request(s3, objRequest);
   return tokenizer(s3request, {
     avoidHeadRequests: true

--- a/lib/s3-request.ts
+++ b/lib/s3-request.ts
@@ -1,8 +1,12 @@
 import { type IRangeRequestClient, type IRangeRequestResponse, parseContentRange } from '@tokenizer/range';
-import { type S3Client, type GetObjectRequest, GetObjectCommand, type GetObjectCommandOutput } from '@aws-sdk/client-s3';
+import { type GetObjectRequest, GetObjectCommand, type GetObjectCommandOutput } from '@aws-sdk/client-s3';
 import { Readable } from 'node:stream';
 
 type ByteRangeRequest = [number, number];
+
+export interface S3RequestClient {
+  send(command: GetObjectCommand, options?: { abortSignal?: AbortSignal }): Promise<GetObjectCommandOutput>;
+}
 
 /**
  * Use S3-client to execute actual HTTP-requests.
@@ -11,7 +15,7 @@ export class S3Request implements IRangeRequestClient {
 
   private readonly abortController = new AbortController();
 
-  constructor(private s3: S3Client, private objRequest: GetObjectRequest) {
+  constructor(private s3: S3RequestClient, private objRequest: GetObjectRequest) {
   }
 
   /**


### PR DESCRIPTION
Updated S3 client type to `S3RequestClient` for better abstraction and flexibility in handling requests. Adjusted relevant functions, imports, and tests to reflect the new interface. This change enhances compatibility and simplifies mocking in tests.